### PR TITLE
Added gRPC Telemetry instrumentation using Prometheus Exporter

### DIFF
--- a/ojp-server/pom.xml
+++ b/ojp-server/pom.xml
@@ -99,6 +99,46 @@
             <version>1.3.0</version>
         </dependency>
 
+        <!-- OpenTelemetry API -->
+        <!-- https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-api -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-api</artifactId>
+            <version>1.52.0</version>
+        </dependency>
+
+        <!-- OpenTelemetry SDK -->
+        <!-- https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-sdk -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-sdk</artifactId>
+            <version>1.52.0</version>
+        </dependency>
+
+        <!-- OpenTelemetry gRPC instrumentation -->
+        <!-- https://mvnrepository.com/artifact/io.opentelemetry.instrumentation/opentelemetry-grpc-1.6 -->
+        <dependency>
+            <groupId>io.opentelemetry.instrumentation</groupId>
+            <artifactId>opentelemetry-grpc-1.6</artifactId>
+            <version>2.17.1-alpha</version>
+        </dependency>
+
+        <!-- Prometheus exporter -->
+        <!-- https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-exporter-prometheus -->
+        <dependency>
+            <groupId>io.opentelemetry</groupId>
+            <artifactId>opentelemetry-exporter-prometheus</artifactId>
+            <version>1.52.0-alpha</version>
+        </dependency>
+
+        <!-- HTTP server for metrics endpoint -->
+        <!-- https://mvnrepository.com/artifact/io.prometheus/simpleclient_httpserver -->
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>0.16.0</version>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/junit/junit -->
         <dependency>
             <groupId>junit</groupId>

--- a/ojp-server/src/main/java/org/openjdbcproxy/grpc/server/GrpcServer.java
+++ b/ojp-server/src/main/java/org/openjdbcproxy/grpc/server/GrpcServer.java
@@ -2,6 +2,7 @@ package org.openjdbcproxy.grpc.server;
 
 import io.grpc.Server;
 import io.grpc.ServerBuilder;
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
 import org.openjdbcproxy.constants.CommonConstants;
 
 import java.io.IOException;
@@ -9,12 +10,17 @@ import java.io.IOException;
 public class GrpcServer {
 
     public static void main(String[] args) throws IOException, InterruptedException {
+        OjpServerTelemetry ojpServerTelemetry = new OjpServerTelemetry();
+        GrpcTelemetry grpcTelemetry = ojpServerTelemetry.createGrpcTelemetry();
+
         Server server = ServerBuilder
                 .forPort(CommonConstants.DEFAULT_PORT_NUMBER)
                 .addService(new StatementServiceImpl(
                         new SessionManagerImpl(),
                         new CircuitBreaker(60000)//TODO pass as parameter currently
-                )).build();
+                ))
+                .intercept(grpcTelemetry.newServerInterceptor())
+                .build();
 
         server.start();
         server.awaitTermination();

--- a/ojp-server/src/main/java/org/openjdbcproxy/grpc/server/OjpServerTelemetry.java
+++ b/ojp-server/src/main/java/org/openjdbcproxy/grpc/server/OjpServerTelemetry.java
@@ -1,0 +1,35 @@
+package org.openjdbcproxy.grpc.server;
+
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.exporter.prometheus.PrometheusHttpServer;
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+
+/**
+ * OJP Server Telemetry Configuration for OpenTelemetry with Prometheus Exporter.
+ * This class provides methods to create a GrpcTelemetry instance with Prometheus metrics.
+ */
+public class OjpServerTelemetry {
+
+	private static final int DEFAULT_PROMETHEUS_PORT = 9090;
+
+	public GrpcTelemetry createGrpcTelemetry() {
+		return createGrpcTelemetry(DEFAULT_PROMETHEUS_PORT);
+	}
+
+	public GrpcTelemetry createGrpcTelemetry(int prometheusPort) {
+		PrometheusHttpServer prometheusServer = PrometheusHttpServer.builder()
+				.setPort(prometheusPort)
+				.build();
+
+		OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
+				.setMeterProvider(
+						SdkMeterProvider.builder()
+								.registerMetricReader(prometheusServer)
+								.build())
+				.build();
+
+		return GrpcTelemetry.create(openTelemetry);
+	}
+}

--- a/ojp-server/src/test/java/org/openjdbcproxy/grpc/server/OjpServerTelemetryTest.java
+++ b/ojp-server/src/test/java/org/openjdbcproxy/grpc/server/OjpServerTelemetryTest.java
@@ -1,0 +1,42 @@
+package org.openjdbcproxy.grpc.server;
+
+import io.opentelemetry.instrumentation.grpc.v1_6.GrpcTelemetry;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class OjpServerTelemetryTest {
+
+	private static GrpcTelemetry grpcTelemetry;
+
+	@BeforeAll
+	static void setUp() {
+		OjpServerTelemetry instrument = new OjpServerTelemetry();
+		grpcTelemetry = instrument.createGrpcTelemetry();
+	}
+
+	@Test
+	void shouldCreateGrpcTelemetrySuccessfully() {
+		assertNotNull(grpcTelemetry);
+		assertNotNull(grpcTelemetry.newServerInterceptor());
+		assertNotNull(grpcTelemetry.newClientInterceptor());
+	}
+
+	@Test
+	void shouldExposePrometheusMetricsEndpoint() throws IOException {
+		HttpURLConnection connection = (HttpURLConnection) URI.create("http://localhost:9090/metrics").toURL().openConnection();
+		connection.setRequestMethod("GET");
+		connection.setConnectTimeout(5000);
+		connection.setReadTimeout(5000);
+
+		assertEquals(200, connection.getResponseCode());
+		assertEquals("text/plain; version=0.0.4; charset=utf-8", connection.getContentType());
+	}
+
+}


### PR DESCRIPTION
This pull request introduces OpenTelemetry integration into the `ojp-server` project to enable distributed tracing and metrics collection, with Prometheus as the metrics exporter. The changes include adding dependencies, configuring telemetry in the gRPC server, and implementing tests to verify the setup.

### OpenTelemetry Integration:

* **Added OpenTelemetry dependencies**: Updated `pom.xml` to include dependencies for OpenTelemetry API, SDK, gRPC instrumentation, Prometheus exporter, and an HTTP server for metrics endpoints. (`ojp-server/pom.xml`, [ojp-server/pom.xmlR102-R141](diffhunk://#diff-2b7b9a44b799c4a0a041d69dabdeffa0a10eaacc51d6bbfe69c393d0975e5b50R102-R141))

* **Telemetry configuration class**: Introduced a new `OjpServerTelemetry` class to configure OpenTelemetry with Prometheus metrics and create a `GrpcTelemetry` instance. This includes setting up a Prometheus HTTP server on port 9090. (`ojp-server/src/main/java/org/openjdbcproxy/grpc/server/OjpServerTelemetry.java`, [ojp-server/src/main/java/org/openjdbcproxy/grpc/server/OjpServerTelemetry.javaR1-R35](diffhunk://#diff-a1f684224ab51db4086e32b32d00a42613a19dae8ad49120fccfa3fb2fa56aa8R1-R35))

### gRPC Server Enhancements:

* **Integrated gRPC telemetry**: Updated `GrpcServer` to use the `GrpcTelemetry` instance from `OjpServerTelemetry` and added a server interceptor for tracing. (`ojp-server/src/main/java/org/openjdbcproxy/grpc/server/GrpcServer.java`, [ojp-server/src/main/java/org/openjdbcproxy/grpc/server/GrpcServer.javaR5-R23](diffhunk://#diff-87029501b6d3e52784ed3ecb1cf87ff167f8083042056dd2b6aaab12af2ee915R5-R23))

### Telemetry sample from Prometheus exporter endpoint

http://localhost:9090/metrics

```
# HELP rpc_server_duration_milliseconds The duration of an inbound RPC invocation.
# TYPE rpc_server_duration_milliseconds histogram
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="0.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="5.0"} 1
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="10.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="25.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="50.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="75.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="100.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="250.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="500.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="750.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="1000.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="2500.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="5000.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="7500.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="10000.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="+Inf"} 2
rpc_server_duration_milliseconds_count{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059"} 2
rpc_server_duration_milliseconds_sum{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="callResource",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059"} 11.1161
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="0.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="5.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="10.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="25.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="50.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="75.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="100.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="250.0"} 1
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="500.0"} 1
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="750.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="1000.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="2500.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="5000.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="7500.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="10000.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="+Inf"} 2
rpc_server_duration_milliseconds_count{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059"} 2
rpc_server_duration_milliseconds_sum{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="connect",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059"} 771.276
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="0.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="5.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="10.0"} 4
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="25.0"} 5
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="50.0"} 5
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="75.0"} 5
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="100.0"} 6
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="250.0"} 6
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="500.0"} 6
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="750.0"} 6
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="1000.0"} 6
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="2500.0"} 6
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="5000.0"} 6
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="7500.0"} 6
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="10000.0"} 6
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="+Inf"} 6
rpc_server_duration_milliseconds_count{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059"} 6
rpc_server_duration_milliseconds_sum{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeQuery",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059"} 122.70750000000001
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="0.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="5.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="10.0"} 5
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="25.0"} 9
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="50.0"} 9
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="75.0"} 9
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="100.0"} 9
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="250.0"} 10
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="500.0"} 10
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="750.0"} 10
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="1000.0"} 10
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="2500.0"} 10
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="5000.0"} 10
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="7500.0"} 10
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="10000.0"} 10
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="+Inf"} 10
rpc_server_duration_milliseconds_count{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059"} 10
rpc_server_duration_milliseconds_sum{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="executeUpdate",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059"} 273.8586
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="0.0"} 0
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="5.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="10.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="25.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="50.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="75.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="100.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="250.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="500.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="750.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="1000.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="2500.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="5000.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="7500.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="10000.0"} 2
rpc_server_duration_milliseconds_bucket{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059",le="+Inf"} 2
rpc_server_duration_milliseconds_count{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059"} 2
rpc_server_duration_milliseconds_sum{network_type="ipv4",otel_scope_name="io.opentelemetry.grpc-1.6",otel_scope_version="2.17.1-alpha",rpc_grpc_status_code="0",rpc_method="terminateSession",rpc_service="com.openjdbcproxy.grpc.StatementService",rpc_system="grpc",server_address="localhost",server_port="1059"} 7.538399999999999
# TYPE target_info gauge
target_info{service_name="unknown_service:java",telemetry_sdk_language="java",telemetry_sdk_name="opentelemetry",telemetry_sdk_version="1.52.0"} 1
````