### PR TITLE
Closes #12: added health check for server and otel

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 22
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 22
+          java-version: 21
           distribution: 'temurin'
           cache: maven
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,10 +86,10 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 22 for ojp-server
+      - name: Set up JDK 21 for ojp-server
         uses: actions/setup-java@v4
         with:
-          java-version: 22
+          java-version: 21
           distribution: 'temurin'
           cache: maven
 

--- a/ojp-server/pom.xml
+++ b/ojp-server/pom.xml
@@ -15,8 +15,8 @@
     </parent>
 
     <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
 
         <grpc.version>1.70.0</grpc.version>
         <slf4j.version>2.0.17</slf4j.version>
@@ -33,6 +33,12 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty</artifactId>
+            <version>${grpc.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-services</artifactId>
             <version>${grpc.version}</version>
         </dependency>
 
@@ -207,7 +213,7 @@
                 <version>${jib.plugin.version}</version>
                 <configuration>
                     <from>
-                        <image>eclipse-temurin:22-jre</image>
+                        <image>eclipse-temurin:21-jre</image>
                     </from>
                     <to>
                         <image>rrobetti/ojp:0.0.5-alpha</image>

--- a/ojp-server/src/main/java/org/openjdbcproxy/grpc/server/OjpHealthManager.java
+++ b/ojp-server/src/main/java/org/openjdbcproxy/grpc/server/OjpHealthManager.java
@@ -1,0 +1,49 @@
+package org.openjdbcproxy.grpc.server;
+
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.protobuf.services.HealthStatusManager;
+import lombok.Getter;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * OJP Health Manager for managing the health status of services in the OJP server.
+ * This class provides methods to initialize the health status manager and set service statuses.
+ */
+public class OjpHealthManager {
+
+	@Getter
+	private static HealthStatusManager healthStatusManager;
+
+	@Getter
+	public enum Services {
+		OJP_SERVER(""),
+		OPENTELEMETRY_SERVICE("opentelemetry_service");
+
+		private final String serviceName;
+
+		Services(String serviceName) {
+			this.serviceName = serviceName;
+		}
+
+	}
+
+	public static void initialize() {
+		if (healthStatusManager == null) {
+			healthStatusManager = new HealthStatusManager();
+			healthStatusManager.clearStatus(StringUtils.EMPTY); // Clear all statuses
+		}
+
+		// Set initial statuses
+		healthStatusManager.setStatus(Services.OJP_SERVER.getServiceName(),
+				HealthCheckResponse.ServingStatus.NOT_SERVING);
+		healthStatusManager.setStatus(Services.OPENTELEMETRY_SERVICE.getServiceName(),
+				HealthCheckResponse.ServingStatus.NOT_SERVING);
+	}
+
+	public static void setServiceStatus(Services service, HealthCheckResponse.ServingStatus status) {
+		if (healthStatusManager == null) {
+			initialize();
+		}
+		healthStatusManager.setStatus(service.getServiceName(), status);
+	}
+}

--- a/ojp-server/src/test/java/org/openjdbcproxy/grpc/server/GrpcServerHealthTest.java
+++ b/ojp-server/src/test/java/org/openjdbcproxy/grpc/server/GrpcServerHealthTest.java
@@ -1,0 +1,131 @@
+package org.openjdbcproxy.grpc.server;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.health.v1.HealthGrpc;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.openjdbcproxy.grpc.server.OjpHealthManager.*;
+
+/**
+ * Integration test for the complete GrpcServer health status functionality.
+ * This test verifies that the health endpoints work correctly with the actual server implementation.
+ */
+@Slf4j
+class GrpcServerHealthTest {
+
+    private static ExecutorService virtualThreadExecutor;
+    private ManagedChannel channel;
+    private HealthGrpc.HealthBlockingStub healthStub;
+
+	@BeforeEach
+    void setUp() {
+		int testPort = findAvailablePort();
+
+        System.setProperty("ojp.server.port", String.valueOf(testPort));
+
+        // Create client channel
+        channel = ManagedChannelBuilder.forAddress("localhost", testPort)
+                .usePlaintext()
+                .build();
+
+        // Create health check stub
+        healthStub = HealthGrpc.newBlockingStub(channel);
+    }
+
+    @AfterEach
+    void tearDown() throws InterruptedException {
+        if (channel != null) {
+            channel.shutdown();
+            channel.awaitTermination(1, TimeUnit.SECONDS);
+        }
+
+        System.clearProperty("ojp.server.port");
+        System.clearProperty("ojp.opentelemetry.enabled");
+    }
+
+    @AfterAll
+    static void cleanUp() {
+        if (virtualThreadExecutor != null) {
+            virtualThreadExecutor.shutdownNow();
+        }
+    }
+
+    @Test
+    void testHealthEndpointServing() {
+        startServer();
+
+        assertHealthStatus(Services.OJP_SERVER, HealthCheckResponse.ServingStatus.SERVING);
+        assertHealthStatus(Services.OPENTELEMETRY_SERVICE, HealthCheckResponse.ServingStatus.SERVING);
+    }
+
+    @Test
+    void testHealthEndpointOtelServiceNotServing() {
+        System.setProperty("ojp.opentelemetry.enabled", "false");
+        startServer();
+
+        assertHealthStatus(Services.OJP_SERVER, HealthCheckResponse.ServingStatus.SERVING);
+        assertHealthStatus(Services.OPENTELEMETRY_SERVICE, HealthCheckResponse.ServingStatus.NOT_SERVING);
+    }
+
+    @Test
+    void testServerHealthEndpointNotServing() {
+        HealthCheckRequest request = HealthCheckRequest.newBuilder()
+                .setService(Services.OJP_SERVER.getServiceName())
+                .build();
+
+        assertThrows(io.grpc.StatusRuntimeException.class, () ->
+                healthStub.check(request), "Expected UNAVAILABLE status when server is not running");
+    }
+
+    // Helpers
+
+    private void assertHealthStatus(Services service, HealthCheckResponse.ServingStatus expectedStatus) {
+        HealthCheckRequest request = HealthCheckRequest.newBuilder()
+                .setService(service.getServiceName())
+                .build();
+
+        HealthCheckResponse response = healthStub.check(request);
+
+        assertNotNull(response);
+        assertEquals(expectedStatus, response.getStatus());
+    }
+
+    private void startServer() {
+		virtualThreadExecutor = Executors.newVirtualThreadPerTaskExecutor();
+        virtualThreadExecutor.submit(() -> {
+            try {
+                String[] args = {};
+                GrpcServer.main(args);
+            } catch (Exception ignored) {
+                log.error("Server interrupted");
+            }
+        });
+
+        try {
+            Thread.sleep(1000); // Wait for server to start
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private int findAvailablePort() {
+        try (java.net.ServerSocket socket = new java.net.ServerSocket(0)) {
+            return socket.getLocalPort();
+        } catch (Exception e) {
+            return 0;
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request introduces significant updates to the `ojp-server` project, focusing on upgrading dependencies, adding health-check functionality, and updating the build configuration. The most notable changes include the integration of a health status manager for gRPC services, upgrading the Java version and Maven compiler settings, and adding tests for the health-check functionality.

### Health-check functionality:
* Added a new `OjpHealthManager` class to manage the health status of gRPC services, including initialization, status updates, and service enumeration (`ojp-server/src/main/java/org/openjdbcproxy/grpc/server/OjpHealthManager.java`).  
* Updated `GrpcServer` to integrate the health status manager, set service statuses, and expose the health service (`ojp-server/src/main/java/org/openjdbcproxy/grpc/server/GrpcServer.java`) [[1]](diffhunk://#diff-87029501b6d3e52784ed3ecb1cf87ff167f8083042056dd2b6aaab12af2ee915R19-R21) [[2]](diffhunk://#diff-87029501b6d3e52784ed3ecb1cf87ff167f8083042056dd2b6aaab12af2ee915R40-R42) [[3]](diffhunk://#diff-87029501b6d3e52784ed3ecb1cf87ff167f8083042056dd2b6aaab12af2ee915R57) [[4]](diffhunk://#diff-87029501b6d3e52784ed3ecb1cf87ff167f8083042056dd2b6aaab12af2ee915R66-R73).  
* Added integration tests for the health-check functionality in `GrpcServerHealthTest`, verifying the serving status of services and handling of edge cases (`ojp-server/src/test/java/org/openjdbcproxy/grpc/server/GrpcServerHealthTest.java`).  

### Dependency and configuration updates:
* Upgraded the Maven compiler source and target versions from 17 to 21 in `pom.xml` (`ojp-server/pom.xml`).  
* Added a new dependency for `grpc-services` to support health-check functionality (`ojp-server/pom.xml`).  
* Updated the base image in the Jib plugin configuration to use `eclipse-temurin:21-jre` instead of `eclipse-temurin:22-jre` (`ojp-server/pom.xml`).  

### Workflow adjustments:
* Downgraded the Java version from 22 to 21 in GitHub Actions workflows (`.github/workflows/docker-build.yml` and `.github/workflows/main.yml`) [[1]](diffhunk://#diff-3414847e2ad632333f775cabb810f0dc0df61a570365df34750a08b00912fe82L26-R29) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L89-R92).  

These changes improve the maintainability, compatibility, and observability of the `ojp-server` project.