### PR TITLE
Move Components section to OJP Components page and link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,34 +111,6 @@ This intelligent allocation of connections helps prevent overloading databases a
 
 ---
 
-## Components
-
-### ojp-server
-The ojp-server is a gRPC server that manages a HikariCP connection pool and abstracts the creation and management of database connections. It supports one or multiple relational databases and provides virtual connections to the ojp-jdbc-driver. The server ensures the number of open real connections is always under control, according to predefined settings, improving database scalability.
-
-### ojp-jdbc-driver
-The ojp-jdbc-driver is an implementation of the JDBC specification. It connects to the ojp-server via the gRPC protocol, sending SQL statements to be executed against the database and reading the responses. The driver works with virtual connections provided by the ojp-server, allowing the application to interact with the database without directly managing real database connections.
-
-Latest version:
-
-         <dependency>
-             <groupId>org.openjproxy</groupId>
-             <artifactId>ojp-jdbc-driver</artifactId>
-             <version>0.1.1-beta</version>
-         </dependency>
-
-
-#### Important: Disable your application's connection pool
-
-When using OJP, disable any existing connection pooling in your application (such as HikariCP, C3P0, or DBCP2) since OJP handles connection pooling at the proxy level. This prevents double-pooling and ensures optimal performance.
-
-**Important**: OJP will not work properly if another connection pool is enabled on the application side. Make sure to disable all application-level connection pooling before using OJP.
-
-### ojp-grpc-commons
-The ojp-grpc-commons module contains the shared gRPC contracts used between the ojp-server and ojp-jdbc-driver. These contracts define the communication protocol and structure for requests and responses exchanged between the server and the driver.
-
----
-
 ## Contributing & Developer Guide
 
 Welcome to OJP! We appreciate your interest in contributing. This guide will help you get started with development.
@@ -154,3 +126,6 @@ Welcome to OJP! We appreciate your interest in contributing. This guide will hel
 <a href=https://github.com/switcherapi>
 <img width="180px" src="documents/images/switcherapi_grey.png" alt="Comunidade Brasil JUG" />
 </a>
+
+- [OJP Components](documents/OJPComponents.md)
+

--- a/documents/OJPComponents.md
+++ b/documents/OJPComponents.md
@@ -1,0 +1,25 @@
+## Components
+
+### ojp-server
+The ojp-server is a gRPC server that manages a HikariCP connection pool and abstracts the creation and management of database connections. It supports one or multiple relational databases and provides virtual connections to the ojp-jdbc-driver. The server ensures the number of open real connections is always under control, according to predefined settings, improving database scalability.
+
+### ojp-jdbc-driver
+The ojp-jdbc-driver is an implementation of the JDBC specification. It connects to the ojp-server via the gRPC protocol, sending SQL statements to be executed against the database and reading the responses. The driver works with virtual connections provided by the ojp-server, allowing the application to interact with the database without directly managing real database connections.
+
+Latest version:
+
+         <dependency>
+             <groupId>org.openjproxy</groupId>
+             <artifactId>ojp-jdbc-driver</artifactId>
+             <version>0.1.1-beta</version>
+         </dependency>
+
+
+#### Important: Disable your application's connection pool
+
+When using OJP, disable any existing connection pooling in your application (such as HikariCP, C3P0, or DBCP2) since OJP handles connection pooling at the proxy level. This prevents double-pooling and ensures optimal performance.
+
+**Important**: OJP will not work properly if another connection pool is enabled on the application side. Make sure to disable all application-level connection pooling before using OJP.
+
+### ojp-grpc-commons
+The ojp-grpc-commons module contains the shared gRPC contracts used between the ojp-server and ojp-jdbc-driver. These contracts define the communication protocol and structure for requests and responses exchanged between the server and the driver.


### PR DESCRIPTION
This PR moves the "Components" section from the main README.md
to a new page located at documents/OJPComponents.md.
This is my first contribution, happy to receive feedback!
