### PR TITLE
Move the OJP Components link reference in the README to the Further documents section

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ If Docker is not available in your environment, you can build and run OJP Server
 - [OJP Server Configuration](documents/configuration/ojp-server-configuration.md) - Server startup options and runtime configuration.
 - [Slow query segregation feature](documents/designs/SLOW_QUERY_SEGREGATION.md) - Feature that prevent connection starvation by slow queries (or statements).
 - [Telemetry and Observability](documents/telemetry/README.md) - OpenTelemetry integration and monitoring setup.
+- [OJP Components](documents/OJPComponents.md) - Core modules that define OJP’s architecture, including the server, JDBC driver, and shared gRPC contracts.
     
 ---
 
@@ -126,6 +127,3 @@ Welcome to OJP! We appreciate your interest in contributing. This guide will hel
 <a href=https://github.com/switcherapi>
 <img width="180px" src="documents/images/switcherapi_grey.png" alt="Comunidade Brasil JUG" />
 </a>
-
-- [OJP Components](documents/OJPComponents.md)
-


### PR DESCRIPTION
This PR moves the link reference for the "OJP Components" section to the  "Further documents" section to improve the organization of the documentation.

Related issue: [55](https://github.com/Open-J-Proxy/ojp/issues/55)