### PR TITLE
Set up a check test configuration for PostgresSavepointTests

### DIFF
--- a/documents/code-contributions/setup_and_testing_ojp_source.md
+++ b/documents/code-contributions/setup_and_testing_ojp_source.md
@@ -26,7 +26,7 @@
    Navigate to the ojp-jdbc-driver folder first:
    ```bash
    cd ojp-jdbc-driver
-   mvn test -DdisablePostgresTests -DdisableMySQLTests -DdisableMariaDBTests
+   mvn test -DdisablePostgresTests -DdisableMySQLTests -DdisableMariaDBTests -DdisableCockroachDBTests -DdisablePostgresXATests
    ```
 **Note:** With the disable flags only H2 integration tests will run, to run the full set of integration tests you have to run all the databases locally, follow the instructions at [Run Local Databases](../../documents/environment-setup/run-local-databases.md)
 

--- a/ojp-jdbc-driver/src/test/java/openjproxy/jdbc/PostgresSavepointTests.java
+++ b/ojp-jdbc-driver/src/test/java/openjproxy/jdbc/PostgresSavepointTests.java
@@ -2,6 +2,7 @@ package openjproxy.jdbc;
 
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
 
@@ -13,13 +14,22 @@ import java.sql.Savepoint;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
-public class SavepointTests {
+public class PostgresSavepointTests {
 
+    private static boolean isTestDisabled;
     private Connection connection;
+
+    @BeforeAll
+    public static void checkTestConfiguration() {
+      isTestDisabled = Boolean.parseBoolean(System.getProperty("disablePostgresTests", "false"));
+    }
 
     @SneakyThrows
     public void setUp(String driverClass, String url, String user, String pwd) throws SQLException {
+        assumeFalse(isTestDisabled, "PostgreSQL tests are disabled");
+
         connection = DriverManager.getConnection(url, user, pwd);
         connection.setAutoCommit(false);
         connection.createStatement().execute(


### PR DESCRIPTION
This PR sets a verification in the test class PostgresSavepointTests to check if the parameter disablePostgresTests is true or false. When true, the integration tests for postgres run, otherwise not.

The class PostgresSavepointTests was renamed from SavepointTests to better reflect its purpose and the README section "Run integration tests" was modified to cover the parameters `-DdisableCockroachDBTests -DdisablePostgresXATests` which were missing in the mvn test instruction.