### PR TITLE
Modified oracle_connections.csv file to take in account the state of …

### DIFF
--- a/ojp-jdbc-driver/src/test/resources/oracle_connections.csv
+++ b/ojp-jdbc-driver/src/test/resources/oracle_connections.csv
@@ -1,1 +1,2 @@
-org.openjproxy.jdbc.Driver,jdbc:ojp[localhost:1059]_oracle:thin:@localhost:1521/XEPDB1,testuser,testpassword
+org.openjproxy.jdbc.Driver,jdbc:ojp[localhost:1059]_oracle:thin:@localhost:1521/XEPDB1,testuser,testpassword,true
+org.openjproxy.jdbc.Driver,jdbc:ojp[localhost:1059]_oracle:thin:@localhost:1521/XEPDB1,testuser,testpassword,false


### PR DESCRIPTION
#71 

I reviewed the files : 
- ojp-server/src/main/java/org/openjproxy/grpc/server/xa/XADataSourceFactory.java
- ojp-jdbc-driver/src/test/java/openjproxy/jdbc/testutil/TestDBUtils.java

and found nothing to change since it is already implemented.

i reviewed the use of TestDBUtils.createConnection() function and made sure it uses the **isXA** variable.

I ran the tests locally and they worked fine for me. 

Feel free to address anything if anything is missing.