### PR TITLE
Add java frameworks navigation links to the introduction README for easier access

### DIFF
--- a/documents/java-frameworks/README.md
+++ b/documents/java-frameworks/README.md
@@ -1,6 +1,10 @@
 # Introduction
 Each folder under this directory have detailed documentation on how to integrate OJP on different frameworks.
 
+- [Spring Boot](spring-boot/README.md)
+- [Quarkus](quarkus/README.md)
+- [Micronaut](micronaut/README.md)
+
 Note that the steps are always similar and follow 3 basic steps:
 
 1. Modify your connection URL to OJP pattern.


### PR DESCRIPTION
This PR adds navigation links for Java Frameworks (Spring Boot, Quarkus, and Micronaut) to the Introduction section of the Get Started page (README.md).

This provides readers with more convenient and smoother access.