### PR TITLE
Implements #229 - Refactor XA transaction handling by introducing XaForgetAction class

### DIFF
--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/action/transaction/XaForgetAction.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/action/transaction/XaForgetAction.java
@@ -1,0 +1,83 @@
+package org.openjproxy.grpc.server.action.transaction;
+
+import com.openjproxy.grpc.XaForgetRequest;
+import com.openjproxy.grpc.XaResponse;
+import io.grpc.stub.StreamObserver;
+import lombok.extern.slf4j.Slf4j;
+import org.openjproxy.grpc.server.Session;
+import org.openjproxy.grpc.server.SessionManager;
+import org.openjproxy.grpc.server.action.Action;
+
+import java.sql.SQLException;
+
+import static org.openjproxy.grpc.server.GrpcExceptionHandler.sendSQLExceptionMetadata;
+import static org.openjproxy.grpc.server.action.transaction.XidHelper.convertXid;
+
+/**
+ * Action to forget a heuristically completed XA transaction branch.
+ * <p>
+ * The forget operation tells the resource manager to forget about a
+ * heuristically
+ * completed transaction branch. This is typically used when a transaction
+ * branch
+ * has been heuristically committed or rolled back, and the transaction manager
+ * wants to inform the resource manager that it no longer needs to track this
+ * branch.
+ * <p>
+ * This action validates that the session is an XA session with an available
+ * XA resource before performing the forget operation.
+ */
+@Slf4j
+public class XaForgetAction implements Action<XaForgetRequest, XaResponse> {
+
+    private final SessionManager sessionManager;
+
+    /**
+     * Creates a new XaForgetAction with the specified session manager.
+     *
+     * @param sessionManager the session manager used to retrieve XA sessions
+     */
+    public XaForgetAction(SessionManager sessionManager) {
+        this.sessionManager = sessionManager;
+    }
+
+    /**
+     * Executes the XA forget operation for the specified transaction branch.
+     * <p>
+     * This method retrieves the XA session from the session manager, validates
+     * that it is an XA session with an available XA resource, converts the
+     * protobuf XID to a javax.transaction.xa.Xid, and calls forget on the
+     * XA resource.
+     *
+     * @param request          the XA forget request containing the session and XID
+     * @param responseObserver the response observer for sending the result
+     */
+    @Override
+    public void execute(XaForgetRequest request, StreamObserver<XaResponse> responseObserver) {
+        log.debug("xaForget: session={}, xid={}",
+                request.getSession().getSessionUUID(), request.getXid());
+
+        try {
+            Session session = sessionManager.getSession(request.getSession());
+            if (session == null || !session.isXA() || session.getXaResource() == null) {
+                throw new SQLException("Session is not an XA session");
+            }
+
+            javax.transaction.xa.Xid xid = convertXid(request.getXid());
+            session.getXaResource().forget(xid);
+
+            com.openjproxy.grpc.XaResponse response = com.openjproxy.grpc.XaResponse.newBuilder()
+                    .setSession(session.getSessionInfo())
+                    .setSuccess(true)
+                    .setMessage("XA forget successful")
+                    .build();
+            responseObserver.onNext(response);
+            responseObserver.onCompleted();
+
+        } catch (Exception e) {
+            log.error("Error in xaForget", e);
+            SQLException sqlException = (e instanceof SQLException ex) ? ex : new SQLException(e);
+            sendSQLExceptionMetadata(sqlException, responseObserver);
+        }
+    }
+}

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/action/transaction/XidHelper.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/action/transaction/XidHelper.java
@@ -1,0 +1,40 @@
+package org.openjproxy.grpc.server.action.transaction;
+
+import com.openjproxy.grpc.XidProto;
+import org.openjproxy.grpc.server.XidImpl;
+
+import javax.transaction.xa.Xid;
+
+/**
+ * Utility class for converting between Protocol Buffer XID messages and
+ * {@link javax.transaction.xa.Xid} instances.
+ * <p>
+ * Provides bidirectional conversion methods to facilitate XA transaction
+ * identifier serialization and deserialization in the gRPC communication layer.
+ */
+public class XidHelper {
+
+    private XidHelper() {}
+
+    /**
+     * Convert protobuf Xid to javax.transaction.xa.Xid.
+     */
+    public static Xid convertXid(XidProto xidProto) {
+        return new XidImpl(
+                xidProto.getFormatId(),
+                xidProto.getGlobalTransactionId().toByteArray(),
+                xidProto.getBranchQualifier().toByteArray()
+        );
+    }
+
+    /**
+     * Convert javax.transaction.xa.Xid to protobuf Xid.
+     */
+    public static XidProto convertXidToProto(javax.transaction.xa.Xid xid) {
+        return XidProto.newBuilder()
+                .setFormatId(xid.getFormatId())
+                .setGlobalTransactionId(com.google.protobuf.ByteString.copyFrom(xid.getGlobalTransactionId()))
+                .setBranchQualifier(com.google.protobuf.ByteString.copyFrom(xid.getBranchQualifier()))
+                .build();
+    }
+}


### PR DESCRIPTION
Implements issue #229 

### Changes

- Moved the xaForget logic from StatementServiceImpl to a new XaForgetAction class for better separation of concerns.
- Removed redundant conversion methods from StatementServiceImpl to streamline the codebase.
- Added XidHelper utility class for converting between Protocol Buffer XID messages and javax.transaction.xa.Xid instances.

Tests were executed in my fork CI/CD. Only the Notify tests did not work since I don't have the keys properly configured.