### PR TITLE
Circuit Breaker: implement per-datasource isolation via Registry pattern

### DIFF
--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreaker.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreaker.java
@@ -5,31 +5,33 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
+import lombok.extern.slf4j.Slf4j;
 /**
  * Implements a basic circuit breaker that counts failures and return the latest error if a threshold is exceeded.
  */
+@Slf4j
 public class CircuitBreaker {
     private static class FailureRecord {
         private volatile SQLException lastError;
         private final AtomicInteger failureCount = new AtomicInteger(0);
         private final AtomicLong openUntil = new AtomicLong(0);
-        private final int failureThreashold;
+        private final int failureThreshold;
 
-        public FailureRecord(int failureThreashold) {
-            this.failureThreashold = failureThreashold;
+        public FailureRecord(int failureThreshold) {
+            this.failureThreshold = failureThreshold;
         }
 
         public void recordFailure(SQLException error, long openMs) {
             lastError = error;
             int failures = failureCount.incrementAndGet();
-            if (failures >= failureThreashold) {
+            if (failures >= failureThreshold) {
                 openUntil.updateAndGet(prev -> Math.max(prev, System.currentTimeMillis() + openMs));
             }
         }
 
         public boolean isOpen() {
             long until = openUntil.get();
-            if (failureCount.get() < failureThreashold) return false;
+            if (failureCount.get() < failureThreshold) return false;
             if (System.currentTimeMillis() > until) {
                 return false;
             }
@@ -38,7 +40,7 @@ public class CircuitBreaker {
 
         public boolean tryReset() {
             long until = openUntil.get();
-            if (System.currentTimeMillis() > until && failureCount.get() >= failureThreashold) {
+            if (System.currentTimeMillis() > until && failureCount.get() >= failureThreshold) {
                 return true;
             }
             return false;
@@ -61,11 +63,12 @@ public class CircuitBreaker {
 
     private final ConcurrentHashMap<String, FailureRecord> state = new ConcurrentHashMap<>();
     private final long openMs;
-    private final int failureThreashold;
-
-    public CircuitBreaker(long openMs, int failureThreashold) {
+    private final int failureThreshold;
+    private final String resourceId;
+    public CircuitBreaker(long openMs, int failureThreshold, String resourceId) {
         this.openMs = openMs;
-        this.failureThreashold = failureThreashold;
+        this.failureThreshold = failureThreshold;
+        this.resourceId = resourceId;
     }
 
     /**
@@ -104,9 +107,12 @@ public class CircuitBreaker {
      * @param error The exception.
      */
     public void onFailure(String sql, SQLException error) {
-        FailureRecord rec = state.computeIfAbsent(sql, s -> new FailureRecord(this.failureThreashold));
+        FailureRecord rec = state.computeIfAbsent(sql, s -> new FailureRecord(this.failureThreshold));
         if (!rec.isOpen()) {
             rec.recordFailure(error, openMs);
+            if (rec.isOpen()){
+                log.warn("Circuit Breaker TRIP: Resource Id [{}] is now OPEN for query key: {}", this.resourceId, sql);
+            }
         }
     }
 }

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreakerRegistry.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/CircuitBreakerRegistry.java
@@ -1,0 +1,20 @@
+package org.openjproxy.grpc.server;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class CircuitBreakerRegistry {
+
+    private ConcurrentHashMap<String, CircuitBreaker> circuitBreakerStore = new ConcurrentHashMap<>();
+    private final long openMs;
+    private final int failureThreshold;
+
+    public CircuitBreakerRegistry(long openMs, int failureThreshold){
+        this.openMs = openMs;
+        this.failureThreshold = failureThreshold;
+    }
+
+
+    public CircuitBreaker get(String key){
+        return circuitBreakerStore.computeIfAbsent(key, k -> new CircuitBreaker(openMs, failureThreshold, key));
+    }
+}

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/GrpcServer.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/GrpcServer.java
@@ -26,7 +26,8 @@ public class GrpcServer {
 
         // Load configuration
         ServerConfiguration config = new ServerConfiguration();
-        
+
+        CircuitBreakerRegistry circuitBreakerRegistry = new CircuitBreakerRegistry(config.getCircuitBreakerTimeout(), config.getCircuitBreakerThreshold());
         // Load external JDBC drivers from configured directory
         logger.info("Loading external JDBC drivers...");
         boolean driversLoaded = DriverLoader.loadDriversFromPath(config.getDriversPath());
@@ -64,10 +65,10 @@ public class GrpcServer {
         SessionManagerImpl sessionManager = new SessionManagerImpl();
         final StatementServiceImpl statementService = new StatementServiceImpl(
                 sessionManager,
-                new CircuitBreaker(config.getCircuitBreakerTimeout(), config.getCircuitBreakerThreshold()),
+                circuitBreakerRegistry,
                 config
         );
-        
+
         NettyServerBuilder serverBuilder = NettyServerBuilder
                 .forPort(config.getServerPort())
                 .executor(Executors.newFixedThreadPool(config.getThreadPoolSize()))
@@ -137,7 +138,7 @@ public class GrpcServer {
             // Shutdown SQL enhancer engine first
             logger.info("Shutting down SQL enhancer engine...");
             statementService.shutdown();
-            
+
             // Shutdown session cleanup task
             if (finalSessionCleanupExecutor != null) {
                 logger.info("Shutting down session cleanup executor...");

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/StatementServiceImpl.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/StatementServiceImpl.java
@@ -93,7 +93,7 @@ public class StatementServiceImpl extends StatementServiceGrpc.StatementServiceI
     // management)
     private final Map<String, XATransactionRegistry> xaRegistries = new ConcurrentHashMap<>();
     private final SessionManager sessionManager;
-    private final CircuitBreaker circuitBreaker;
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
 
     // Per-datasource slow query segregation managers
     private final Map<String, SlowQuerySegregationManager> slowQuerySegregationManagers = new ConcurrentHashMap<>();
@@ -119,10 +119,10 @@ public class StatementServiceImpl extends StatementServiceGrpc.StatementServiceI
     // ActionContext for refactored actions
     private final org.openjproxy.grpc.server.action.ActionContext actionContext;
 
-    public StatementServiceImpl(SessionManager sessionManager, CircuitBreaker circuitBreaker,
+    public StatementServiceImpl(SessionManager sessionManager, CircuitBreakerRegistry circuitBreakerRegistry,
             ServerConfiguration serverConfiguration) {
         this.sessionManager = sessionManager;
-        this.circuitBreaker = circuitBreaker;
+        this.circuitBreakerRegistry = circuitBreakerRegistry;
         // Server configuration for creating segregation managers
         this.sqlEnhancerEngine = new org.openjproxy.grpc.server.sql.SqlEnhancerEngine(
                 serverConfiguration.isSqlEnhancerEnabled());
@@ -140,7 +140,7 @@ public class StatementServiceImpl extends StatementServiceGrpc.StatementServiceI
                 xaCoordinator,
                 clusterHealthTracker,
                 sessionManager,
-                circuitBreaker,
+                circuitBreakerRegistry,
                 serverConfiguration);
     }
 
@@ -225,48 +225,12 @@ public class StatementServiceImpl extends StatementServiceGrpc.StatementServiceI
     @Override
     public void executeUpdate(StatementRequest request, StreamObserver<OpResult> responseObserver) {
         log.info("Executing update {}", request.getSql());
-        
-        // Update session activity
-        updateSessionActivity(request.getSession());
-        
-        String stmtHash = SqlStatementXXHash.hashSqlQuery(request.getSql());
 
-        // Process cluster health from the request
-        ProcessClusterHealthAction.getInstance().execute(actionContext, request.getSession());
-
-        try {
-            circuitBreaker.preCheck(stmtHash);
-
-            // Get the appropriate slow query segregation manager for this datasource
-            String connHash = request.getSession().getConnHash();
-            SlowQuerySegregationManager manager = getSlowQuerySegregationManagerForConnection(connHash);
-
-            // Execute with slow query segregation
-            OpResult result = manager.executeWithSegregation(stmtHash, () -> executeUpdateInternal(request));
-
+        executeWithResilience(request, responseObserver, () -> {
+            OpResult result = executeUpdateInternal(request);
             responseObserver.onNext(result);
             responseObserver.onCompleted();
-            circuitBreaker.onSuccess(stmtHash);
-
-        } catch (SQLDataException e) {
-            circuitBreaker.onFailure(stmtHash, e);
-            log.error("SQL data failure during update execution: " + e.getMessage(), e);
-            sendSQLExceptionMetadata(e, responseObserver, SqlErrorType.SQL_DATA_EXCEPTION);
-        } catch (SQLException e) {
-            circuitBreaker.onFailure(stmtHash, e);
-            log.error("Failure during update execution: " + e.getMessage(), e);
-            sendSQLExceptionMetadata(e, responseObserver);
-        } catch (Exception e) {
-            log.error("Unexpected failure during update execution: " + e.getMessage(), e);
-            if (e.getCause() instanceof SQLException sqlException) {
-                circuitBreaker.onFailure(stmtHash, sqlException);
-                sendSQLExceptionMetadata(sqlException, responseObserver);
-            } else {
-                SQLException sqlException = new SQLException("Unexpected error: " + e.getMessage(), e);
-                circuitBreaker.onFailure(stmtHash, sqlException);
-                sendSQLExceptionMetadata(sqlException, responseObserver);
-            }
-        }
+        }, SqlErrorType.SQL_DATA_EXCEPTION, "update");
     }
 
     /**
@@ -370,44 +334,10 @@ public class StatementServiceImpl extends StatementServiceGrpc.StatementServiceI
     @Override
     public void executeQuery(StatementRequest request, StreamObserver<OpResult> responseObserver) {
         log.info("Executing query for {}", request.getSql());
-        
-        // Update session activity
-        updateSessionActivity(request.getSession());
-        
-        String stmtHash = SqlStatementXXHash.hashSqlQuery(request.getSql());
 
-        // Process cluster health from the request
-        ProcessClusterHealthAction.getInstance().execute(actionContext, request.getSession());
-
-        try {
-            circuitBreaker.preCheck(stmtHash);
-
-            // Get the appropriate slow query segregation manager for this datasource
-            String connHash = request.getSession().getConnHash();
-            SlowQuerySegregationManager manager = getSlowQuerySegregationManagerForConnection(connHash);
-
-            // Execute with slow query segregation
-            manager.executeWithSegregation(stmtHash, () -> {
-                executeQueryInternal(request, responseObserver);
-                return null; // Void return for query execution
-            });
-
-            circuitBreaker.onSuccess(stmtHash);
-        } catch (SQLException e) {
-            circuitBreaker.onFailure(stmtHash, e);
-            log.error("Failure during query execution: " + e.getMessage(), e);
-            sendSQLExceptionMetadata(e, responseObserver);
-        } catch (Exception e) {
-            log.error("Unexpected failure during query execution: " + e.getMessage(), e);
-            if (e.getCause() instanceof SQLException sqlException) {
-                circuitBreaker.onFailure(stmtHash, sqlException);
-                sendSQLExceptionMetadata(sqlException, responseObserver);
-            } else {
-                SQLException sqlException = new SQLException("Unexpected error: " + e.getMessage(), e);
-                circuitBreaker.onFailure(stmtHash, sqlException);
-                sendSQLExceptionMetadata(sqlException, responseObserver);
-            }
-        }
+        executeWithResilience(request, responseObserver, () -> {
+            executeQueryInternal(request, responseObserver);
+        }, null, "query");
     }
 
     /**
@@ -432,21 +362,21 @@ public class StatementServiceImpl extends StatementServiceGrpc.StatementServiceI
                 // Get the DataSource for this connection
                 String dsKey = dto.getSession().getConnHash();
                 DataSource dataSource = datasourceMap.get(dsKey);
-                
+
                 if (dataSource != null) {
                     // Get catalog and schema from the connection
                     Connection connection = dto.getConnection();
                     String catalogName = connection.getCatalog();
                     String schemaName = connection.getSchema();
-                    
+
                     // PostgreSQL: Use "public" schema if schema name is null or empty
                     // This ensures tables created in the default schema are visible to Calcite
-                    if ((schemaName == null || schemaName.isEmpty()) && 
+                    if ((schemaName == null || schemaName.isEmpty()) &&
                         connection.getMetaData().getDatabaseProductName().equalsIgnoreCase("PostgreSQL")) {
                         schemaName = "public";
                         log.debug("Using default PostgreSQL 'public' schema for schema loading");
                     }
-                    
+
                     // Ensure schema is loaded (thread-safe, idempotent)
                     sqlEnhancerEngine.ensureSchemaLoaded(dataSource, catalogName, schemaName);
                 } else {
@@ -456,7 +386,7 @@ public class StatementServiceImpl extends StatementServiceGrpc.StatementServiceI
                 // Log but don't fail - enhancement can proceed without schema
                 log.warn("Failed to ensure schema loaded: {}", e.getMessage());
             }
-            
+
             org.openjproxy.grpc.server.sql.SqlEnhancementResult result = sqlEnhancerEngine.enhance(sql);
             sql = result.getEnhancedSql();
 
@@ -837,6 +767,75 @@ public class StatementServiceImpl extends StatementServiceGrpc.StatementServiceI
                 resultSetUUID, new HydratedResultSetMetadata(rs.getMetaData()));
     }
 
+    /**
+     * Helper method to centralize session validation, activity updates, cluster health processing,
+     * circuit breaker checks, and slow query segregation for statement execution.
+     * This resolves SonarQube duplication issues.
+     */
+    private void executeWithResilience(StatementRequest request, StreamObserver<OpResult> responseObserver,
+                                       StatementExecution executionLogic, SqlErrorType sqlDataExceptionType, String operationName) {
+
+        // Ensure session isn't null
+        if (request.getSession() == null || StringUtils.isBlank(request.getSession().getConnHash())) {
+            sendSQLExceptionMetadata(new SQLException("Invalid request: Session or ConnHash is missing"), responseObserver);
+            log.error("Invalid {} request: Session or ConnHash is missing", operationName);
+            return;
+        }
+
+        // Update session activity
+        updateSessionActivity(request.getSession());
+
+        String stmtHash = SqlStatementXXHash.hashSqlQuery(request.getSql());
+        // Process cluster health from the request
+        ProcessClusterHealthAction.getInstance().execute(actionContext, request.getSession());
+
+
+        String connHash = request.getSession().getConnHash();
+        CircuitBreaker circuitBreaker = circuitBreakerRegistry.get(connHash);
+
+        try {
+            circuitBreaker.preCheck(stmtHash);
+
+            // Get the appropriate slow query segregation manager for this datasource
+            SlowQuerySegregationManager manager = getSlowQuerySegregationManagerForConnection(connHash);
+
+            // Execute with slow query segregation
+            manager.executeWithSegregation(stmtHash, () -> {
+                executionLogic.execute();
+                return null;
+            });
+
+            circuitBreaker.onSuccess(stmtHash);
+
+        } catch(SQLDataException e) {
+            circuitBreaker.onFailure(stmtHash, e);
+            log.error("SQL data failure during {} execution: {}",
+                    operationName, e.getMessage(), e);
+            SqlErrorType type = sqlDataExceptionType != null
+                    ? sqlDataExceptionType
+                    : SqlErrorType.SQL_EXCEPTION;
+
+            sendSQLExceptionMetadata(e, responseObserver, type);
+
+        } catch (SQLException e) {
+            circuitBreaker.onFailure(stmtHash, e);
+            log.error("SQL failure during {} execution: {}",
+                    operationName, e.getMessage(), e);
+            sendSQLExceptionMetadata(e, responseObserver);
+        } catch (Exception e) {
+            log.error("Unexpected failure during {} execution: {}",
+                    operationName, e.getMessage(), e);
+            if (e.getCause() instanceof SQLException sqlException) {
+                circuitBreaker.onFailure(stmtHash, sqlException);
+                sendSQLExceptionMetadata(sqlException, responseObserver);
+            } else {
+                SQLException sqlException = new SQLException("Unexpected error: " + e.getMessage(), e);
+                circuitBreaker.onFailure(stmtHash, sqlException);
+                sendSQLExceptionMetadata(sqlException, responseObserver);
+            }
+        }
+    }
+
     // ===== XA Transaction Operations =====
 
     @Override
@@ -904,7 +903,7 @@ public class StatementServiceImpl extends StatementServiceGrpc.StatementServiceI
         org.openjproxy.grpc.server.action.transaction.XaIsSameRMAction.getInstance()
                 .execute(actionContext, request, responseObserver);
     }
-    
+
     /**
      * Shuts down the SQL enhancer engine and releases associated resources.
      * This method should be called during server shutdown to ensure proper cleanup.
@@ -914,5 +913,10 @@ public class StatementServiceImpl extends StatementServiceGrpc.StatementServiceI
             log.info("Shutting down SQL enhancer engine");
             sqlEnhancerEngine.shutdown();
         }
+    }
+
+    @FunctionalInterface
+    private interface StatementExecution {
+        void execute() throws Exception;
     }
 }

--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/action/ActionContext.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/action/ActionContext.java
@@ -1,11 +1,11 @@
 package org.openjproxy.grpc.server.action;
 
 import com.openjproxy.grpc.DbName;
-import org.openjproxy.grpc.server.CircuitBreaker;
-import org.openjproxy.grpc.server.ClusterHealthTracker;
 import org.openjproxy.grpc.server.MultinodeXaCoordinator;
-import org.openjproxy.grpc.server.ServerConfiguration;
+import org.openjproxy.grpc.server.ClusterHealthTracker;
 import org.openjproxy.grpc.server.SessionManager;
+import org.openjproxy.grpc.server.CircuitBreakerRegistry;
+import org.openjproxy.grpc.server.ServerConfiguration;
 import org.openjproxy.grpc.server.SlowQuerySegregationManager;
 import org.openjproxy.grpc.server.UnpooledConnectionDetails;
 import org.openjproxy.xa.pool.XATransactionRegistry;
@@ -104,12 +104,13 @@ public class ActionContext {
      * Thread-safe, shared across all actions.
      */
     private final SessionManager sessionManager;
-    
+
     /**
-     * Circuit breaker for protecting against cascading failures.
-     * Thread-safe, shared across all actions.
+     * Registry of circuit breakers providing isolated protection against cascading failures
+     * per datasource. Thread-safe and shared across all actions to ensure consistent
+     * state management.
      */
-    private final CircuitBreaker circuitBreaker;
+    private final CircuitBreakerRegistry circuitBreakerRegistry;
     
     /**
      * Server-wide configuration.
@@ -130,7 +131,7 @@ public class ActionContext {
             MultinodeXaCoordinator xaCoordinator,
             ClusterHealthTracker clusterHealthTracker,
             SessionManager sessionManager,
-            CircuitBreaker circuitBreaker,
+            CircuitBreakerRegistry circuitBreakerRegistry,
             ServerConfiguration serverConfiguration) {
         
         this.datasourceMap = datasourceMap;
@@ -143,7 +144,7 @@ public class ActionContext {
         this.xaCoordinator = xaCoordinator;
         this.clusterHealthTracker = clusterHealthTracker;
         this.sessionManager = sessionManager;
-        this.circuitBreaker = circuitBreaker;
+        this.circuitBreakerRegistry = circuitBreakerRegistry;
         this.serverConfiguration = serverConfiguration;
     }
     
@@ -193,8 +194,9 @@ public class ActionContext {
         return sessionManager;
     }
     
-    public CircuitBreaker getCircuitBreaker() {
-        return circuitBreaker;
+
+    public CircuitBreakerRegistry getCircuitBreakerRegistry() {
+        return circuitBreakerRegistry;
     }
     
     public ServerConfiguration getServerConfiguration() {

--- a/ojp-server/src/test/java/org/openjproxy/grpc/server/CircuitBreakerRegistryTest.java
+++ b/ojp-server/src/test/java/org/openjproxy/grpc/server/CircuitBreakerRegistryTest.java
@@ -1,0 +1,57 @@
+package org.openjproxy.grpc.server;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CircuitBreakerRegistryTest {
+    private CircuitBreakerRegistry registry;
+    private int openMs = 1000;
+    private int failureThreshold = 3;
+
+    @BeforeEach
+    void setUp(){
+        this.registry = new CircuitBreakerRegistry(openMs, failureThreshold);
+    }
+
+    @Test
+    void testIdentityPersistence(){
+        CircuitBreaker cb1_first = registry.get("DB-1");
+        CircuitBreaker cb1_second = registry.get("DB-1");
+        CircuitBreaker cb2 = registry.get("DB-2");
+
+        assertSame(cb1_first, cb1_second, "Registry should return the same instance for the same key");
+        assertNotEquals(cb1_first, cb2, "Registry must return different instances for different keys");
+    }
+
+    @Test
+    void testCrossTenantIsolation(){
+        CircuitBreaker db1 = registry.get("DB-1");
+        CircuitBreaker db2 = registry.get("DB-2");
+
+        String sql = "SELECT 1";
+        SQLException sqlException = new SQLException("Database down");
+
+        // Step 1: Trip the breaker for DB-1
+        for (int i = 0; i < failureThreshold; i++) {
+            db1.onFailure(sql, sqlException);
+        }
+
+        // Step 2: Verify DB-1 is OPEN (blocked)
+        assertThrows(SQLException.class, () -> db1.preCheck(sql),
+                "DB-1 should be tripped and blocking queries"
+        );
+
+        // Step 3: Verify DB-2 is still CLOSED (healthy)
+        assertDoesNotThrow(() -> db2.preCheck(sql),
+                "DB-2 should NOT be affected by DB-1's failure"
+        );
+
+        // Step 4: Verify DB-2 can succeed independently
+        db2.onSuccess(sql);
+        assertDoesNotThrow(() -> db2.preCheck(sql));
+    }
+}

--- a/ojp-server/src/test/java/org/openjproxy/grpc/server/CircuitBreakerTest.java
+++ b/ojp-server/src/test/java/org/openjproxy/grpc/server/CircuitBreakerTest.java
@@ -14,16 +14,18 @@ class CircuitBreakerTest {
     private static final int THREE_HUNDRED = 300;
     private static final int FOUR_HUNDRED = 400;
     private static final int FIVE_HUNDRED = 500;
+    private static final String DATA_SOURCE = "Test-DS";
+    
 
     @Test
     void testAllowsWhenNoFailures() {
-        CircuitBreaker breaker = new CircuitBreaker(THOUSAND, FAILURE_THRESHOLD);
+        CircuitBreaker breaker = new CircuitBreaker(THOUSAND, FAILURE_THRESHOLD, DATA_SOURCE);
         assertDoesNotThrow(() -> breaker.preCheck("SELECT 1"));
     }
 
     @Test
     void testBlocksAfterThreeFailures() {
-        CircuitBreaker breaker = new CircuitBreaker(5000, 3);
+        CircuitBreaker breaker = new CircuitBreaker(5000, FAILURE_THRESHOLD, DATA_SOURCE);
         String sql = "SELECT * FROM test";
         SQLException ex = new SQLException("fail");
         // Fail three times
@@ -37,7 +39,7 @@ class CircuitBreakerTest {
 
     @Test
     void testAllowsAgainAfterOpenTimeoutAndSuccessResets() throws InterruptedException, SQLException {
-        CircuitBreaker breaker = new CircuitBreaker(THREE_HUNDRED, FAILURE_THRESHOLD);
+        CircuitBreaker breaker = new CircuitBreaker(THREE_HUNDRED, FAILURE_THRESHOLD, DATA_SOURCE);
         String sql = "UPDATE X SET Y=1";
         SQLException ex = new SQLException("fail");
 
@@ -58,7 +60,7 @@ class CircuitBreakerTest {
 
     @Test
     void testResetsOnSuccess() throws SQLException {
-        CircuitBreaker breaker = new CircuitBreaker(THOUSAND, FAILURE_THRESHOLD);
+        CircuitBreaker breaker = new CircuitBreaker(THOUSAND, FAILURE_THRESHOLD, DATA_SOURCE);
         String sql = "INSERT X";
         SQLException ex = new SQLException("fail2");
         breaker.onFailure(sql, ex);
@@ -71,7 +73,7 @@ class CircuitBreakerTest {
 
     @Test
     void testOnFailureIsNoOpWhenAlreadyOpen() {
-        CircuitBreaker breaker = new CircuitBreaker(FIVE_HUNDRED, FAILURE_THRESHOLD);
+        CircuitBreaker breaker = new CircuitBreaker(FIVE_HUNDRED, FAILURE_THRESHOLD, DATA_SOURCE);
         String sql = "SELECT fail";
         SQLException ex1 = new SQLException("fail1");
         SQLException ex2 = new SQLException("fail2");

--- a/ojp-server/src/test/java/org/openjproxy/grpc/server/PerDatasourceSlowQuerySegregationTest.java
+++ b/ojp-server/src/test/java/org/openjproxy/grpc/server/PerDatasourceSlowQuerySegregationTest.java
@@ -5,6 +5,7 @@ import com.openjproxy.grpc.SessionInfo;
 import io.grpc.stub.StreamObserver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.openjproxy.grpc.ProtoConverter;
 import org.openjproxy.grpc.server.utils.ConnectionHashGenerator;
 
@@ -20,7 +21,7 @@ import static org.mockito.Mockito.mock;
  * Test to verify that each datasource gets its own SlowQuerySegregationManager
  * with pool sizes based on actual HikariCP configuration.
  */
-class PerDatasourceSlowQuerySegregationTest {
+public class PerDatasourceSlowQuerySegregationTest {
 
     private StatementServiceImpl statementService;
     private ServerConfiguration serverConfiguration;
@@ -31,9 +32,13 @@ class PerDatasourceSlowQuerySegregationTest {
         System.setProperty("ojp.server.slowQuerySegregation.enabled", "true");
         serverConfiguration = new ServerConfiguration();
         SessionManager sessionManager = mock(SessionManager.class);
-        CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+        // Create a real Registry using the configuration
+        CircuitBreakerRegistry circuitBreakerRegistry = new CircuitBreakerRegistry(
+                serverConfiguration.getCircuitBreakerTimeout(),
+                serverConfiguration.getCircuitBreakerThreshold()
+        );
 
-        statementService = new StatementServiceImpl(sessionManager, circuitBreaker, serverConfiguration);
+        statementService = new StatementServiceImpl(sessionManager, circuitBreakerRegistry, serverConfiguration);
     }
 
     @org.junit.jupiter.api.AfterEach
@@ -47,7 +52,7 @@ class PerDatasourceSlowQuerySegregationTest {
         Properties clientProperties1 = new Properties();
         clientProperties1.setProperty("ojp.connection.pool.maximumPoolSize", "10");
         clientProperties1.setProperty("ojp.connection.pool.minimumIdle", "2");
-
+        
         Map<String, Object> propertiesMap1 = new HashMap<>();
         for (String key : clientProperties1.stringPropertyNames()) {
             propertiesMap1.put(key, clientProperties1.getProperty(key));
@@ -57,7 +62,7 @@ class PerDatasourceSlowQuerySegregationTest {
         Properties clientProperties2 = new Properties();
         clientProperties2.setProperty("ojp.connection.pool.maximumPoolSize", "20");
         clientProperties2.setProperty("ojp.connection.pool.minimumIdle", "5");
-
+        
         Map<String, Object> propertiesMap2 = new HashMap<>();
         for (String key : clientProperties2.stringPropertyNames()) {
             propertiesMap2.put(key, clientProperties2.getProperty(key));
@@ -80,8 +85,8 @@ class PerDatasourceSlowQuerySegregationTest {
                 .addAllProperties(ProtoConverter.propertiesToProto(propertiesMap2))
                 .build();
 
-        StreamObserver<SessionInfo> responseObserver1 = newNoopObserver();
-        StreamObserver<SessionInfo> responseObserver2 = newNoopObserver();
+        StreamObserver<SessionInfo> responseObserver1 = Mockito.mock(StreamObserver.class);
+        StreamObserver<SessionInfo> responseObserver2 = Mockito.mock(StreamObserver.class);
 
         // Connect with first datasource
         statementService.connect(connectionDetails1, responseObserver1);
@@ -92,11 +97,10 @@ class PerDatasourceSlowQuerySegregationTest {
         // Use reflection to access the private slowQuerySegregationManagers map
         Field managersField = StatementServiceImpl.class.getDeclaredField("slowQuerySegregationManagers");
         managersField.setAccessible(true);
-
-        Object managersValue = managersField.get(statementService);
-        assertNotNull(managersValue);
-        assertInstanceOf(Map.class, managersValue);
-        Map<?, ?> managers = (Map<?, ?>) managersValue;
+        
+        @SuppressWarnings("unchecked")
+        Map<String, SlowQuerySegregationManager> managers = 
+                (Map<String, SlowQuerySegregationManager>) managersField.get(statementService);
 
         // Verify that we have two separate managers
         assertEquals(2, managers.size(), "Should have created separate managers for each datasource");
@@ -105,13 +109,8 @@ class PerDatasourceSlowQuerySegregationTest {
         String connHash1 = ConnectionHashGenerator.hashConnectionDetails(connectionDetails1);
         String connHash2 = ConnectionHashGenerator.hashConnectionDetails(connectionDetails2);
 
-        Object managerValue1 = managers.get(connHash1);
-        Object managerValue2 = managers.get(connHash2);
-        assertInstanceOf(SlowQuerySegregationManager.class, managerValue1);
-        assertInstanceOf(SlowQuerySegregationManager.class, managerValue2);
-
-        SlowQuerySegregationManager manager1 = (SlowQuerySegregationManager) managerValue1;
-        SlowQuerySegregationManager manager2 = (SlowQuerySegregationManager) managerValue2;
+        SlowQuerySegregationManager manager1 = managers.get(connHash1);
+        SlowQuerySegregationManager manager2 = managers.get(connHash2);
 
         assertNotNull(manager1, "Manager for first datasource should exist");
         assertNotNull(manager2, "Manager for second datasource should exist");
@@ -126,20 +125,20 @@ class PerDatasourceSlowQuerySegregationTest {
         assertNotNull(manager2.getSlotManager(), "Manager 2 should have slot manager");
 
         // Pool sizes should match the configured values (10 and 20)
-        assertEquals(10, manager1.getSlotManager().getTotalSlots(),
+        assertEquals(10, manager1.getSlotManager().getTotalSlots(), 
                 "Manager 1 should have 10 total slots based on pool size");
-        assertEquals(20, manager2.getSlotManager().getTotalSlots(),
+        assertEquals(20, manager2.getSlotManager().getTotalSlots(), 
                 "Manager 2 should have 20 total slots based on pool size");
 
         // Verify slot distribution (20% slow, 80% fast by default)
-        assertEquals(2, manager1.getSlotManager().getSlowSlots(),
+        assertEquals(2, manager1.getSlotManager().getSlowSlots(), 
                 "Manager 1 should have 2 slow slots (20% of 10)");
-        assertEquals(8, manager1.getSlotManager().getFastSlots(),
+        assertEquals(8, manager1.getSlotManager().getFastSlots(), 
                 "Manager 1 should have 8 fast slots (80% of 10)");
 
-        assertEquals(4, manager2.getSlotManager().getSlowSlots(),
+        assertEquals(4, manager2.getSlotManager().getSlowSlots(), 
                 "Manager 2 should have 4 slow slots (20% of 20)");
-        assertEquals(16, manager2.getSlotManager().getFastSlots(),
+        assertEquals(16, manager2.getSlotManager().getFastSlots(), 
                 "Manager 2 should have 16 fast slots (80% of 20)");
     }
 
@@ -148,7 +147,7 @@ class PerDatasourceSlowQuerySegregationTest {
         // Create properties
         Properties clientProperties = new Properties();
         clientProperties.setProperty("ojp.connection.pool.maximumPoolSize", "15");
-
+        
         Map<String, Object> propertiesMap = new HashMap<>();
         for (String key : clientProperties.stringPropertyNames()) {
             propertiesMap.put(key, clientProperties.getProperty(key));
@@ -163,22 +162,22 @@ class PerDatasourceSlowQuerySegregationTest {
                 .addAllProperties(ProtoConverter.propertiesToProto(propertiesMap))
                 .build();
 
-        StreamObserver<SessionInfo> responseObserver = newNoopObserver();
+        StreamObserver<SessionInfo> responseObserver = Mockito.mock(StreamObserver.class);
         statementService.connect(connectionDetails, responseObserver);
 
         // Use reflection to call the private method to get manager
         String connHash = ConnectionHashGenerator.hashConnectionDetails(connectionDetails);
-
+        
         java.lang.reflect.Method getManagerMethod = StatementServiceImpl.class
                 .getDeclaredMethod("getSlowQuerySegregationManagerForConnection", String.class);
         getManagerMethod.setAccessible(true);
-
-        SlowQuerySegregationManager manager =
+        
+        SlowQuerySegregationManager manager = 
                 (SlowQuerySegregationManager) getManagerMethod.invoke(statementService, connHash);
 
         assertNotNull(manager, "Should return existing manager for connection hash");
         assertTrue(manager.isEnabled(), "Manager should be enabled");
-        assertEquals(15, manager.getSlotManager().getTotalSlots(),
+        assertEquals(15, manager.getSlotManager().getTotalSlots(), 
                 "Manager should have 15 total slots based on pool size");
     }
 
@@ -188,27 +187,11 @@ class PerDatasourceSlowQuerySegregationTest {
         java.lang.reflect.Method getManagerMethod = StatementServiceImpl.class
                 .getDeclaredMethod("getSlowQuerySegregationManagerForConnection", String.class);
         getManagerMethod.setAccessible(true);
-
-        SlowQuerySegregationManager manager =
+        
+        SlowQuerySegregationManager manager = 
                 (SlowQuerySegregationManager) getManagerMethod.invoke(statementService, "non-existent-hash");
 
         assertNotNull(manager, "Should return fallback manager for non-existent connection hash");
         assertFalse(manager.isEnabled(), "Fallback manager should be disabled");
-    }
-
-    private static StreamObserver<SessionInfo> newNoopObserver() {
-        return new StreamObserver<>() {
-            @Override
-            public void onNext(SessionInfo value) {
-            }
-
-            @Override
-            public void onError(Throwable t) {
-            }
-
-            @Override
-            public void onCompleted() {
-            }
-        };
     }
 }


### PR DESCRIPTION
Replaced the global CircuitBreaker singleton with a CircuitBreakerRegistry to provide fault isolation between different database backends. Previously, if one database failed, the circuit breaker would trip for all databases.

Key Changes:
- Isolation: Created CircuitBreakerRegistry to manage a dedicated circuit breaker instance per connHash.
- Thread Safety: Implemented ConcurrentHashMap.computeIfAbsent for lock-free, thread-safe breaker instantiation.
- Architecture: Updated StatementServiceImpl and ActionContext to inject the Registry instead of a single breaker.
- Observability: Circuit breaker logs now include the Datasource Name (e.g., [DB-1]) for easier debugging.

Testing
- Added CircuitBreakerRegistryTest to verify that tripping one datasource does not block others.
- Verified that all 347 existing tests pass (mvn test).