### PR TITLE
fix: replace string concatenation with parameterized logging in SessionManagerImpl

### DIFF
--- a/ojp-server/src/main/java/org/openjproxy/grpc/server/SessionManagerImpl.java
+++ b/ojp-server/src/main/java/org/openjproxy/grpc/server/SessionManagerImpl.java
@@ -51,33 +51,33 @@ public class SessionManagerImpl implements SessionManager {
 
     @Override
     public SessionInfo createSession(String clientUUID, Connection connection) {
-        log.info("Create session for client uuid " + clientUUID);
+        log.info("Create session for client uuid {}", clientUUID);
         String connectionHash = connectionHashMap.get(clientUUID);
         CacheConfiguration cacheConfig = getCacheConfiguration(connectionHash);
         Session session = new Session(connection, connectionHash, clientUUID, false, null, cacheConfig);
-        log.info("Session " + session.getSessionUUID() + " created for client uuid " + clientUUID);
+        log.info("Session {} created for client uuid {}", session.getSessionUUID(), clientUUID);
         this.sessionMap.put(session.getSessionUUID(), session);
         return session.getSessionInfo();
     }
 
     @Override
     public SessionInfo createXASession(String clientUUID, Connection connection, XAConnection xaConnection) {
-        log.info("Create XA session for client uuid " + clientUUID);
+        log.info("Create XA session for client uuid {}", clientUUID);
         String connectionHash = connectionHashMap.get(clientUUID);
         CacheConfiguration cacheConfig = getCacheConfiguration(connectionHash);
         Session session = new Session(connection, connectionHash, clientUUID, true, xaConnection, cacheConfig);
-        log.info("XA Session " + session.getSessionUUID() + " created for client uuid " + clientUUID);
+        log.info("XA Session {} created for client uuid {}", session.getSessionUUID(), clientUUID);
         this.sessionMap.put(session.getSessionUUID(), session);
         return session.getSessionInfo();
     }
 
     @Override
     public SessionInfo createDeferredXASession(String clientUUID, String connectionHash) {
-        log.info("Create deferred XA session for client uuid " + clientUUID);
+        log.info("Create deferred XA session for client uuid {}", clientUUID);
         CacheConfiguration cacheConfig = getCacheConfiguration(connectionHash);
         // Create session without XAConnection - will be bound later via bindXAConnection()
         Session session = new Session(null, connectionHash, clientUUID, true, null, cacheConfig);
-        log.info("Deferred XA Session " + session.getSessionUUID() + " created for client uuid " + clientUUID);
+        log.info("Deferred XA Session {} created for client uuid {}", session.getSessionUUID(), clientUUID);
         this.sessionMap.put(session.getSessionUUID(), session);
         return session.getSessionInfo();
     }
@@ -188,7 +188,7 @@ public class SessionManagerImpl implements SessionManager {
 
     @Override
     public void terminateSession(SessionInfo sessionInfo) throws SQLException {
-        log.info("Terminating session -> " + sessionInfo.getSessionUUID());
+        log.info("Terminating session -> {}", sessionInfo.getSessionUUID());
         Session targetSession = this.sessionMap.remove(sessionInfo.getSessionUUID());
 
         // Handle case where session doesn't exist on this server (multinode scenario)


### PR DESCRIPTION
Fixes #468

## Summary
Replaced string concatenation with SLF4J parameterized logging in SessionManagerImpl.

## Problem
Using `+` in log calls causes unnecessary string construction even when the log level is disabled, which is inefficient.

## Solution
Changed all log.info() statements to use SLF4J's `{}` placeholders.

## Impact
No functional changes. Reduces overhead when INFO logging is disabled.